### PR TITLE
enhance: useRemember return signal instead of stores

### DIFF
--- a/src/useRemember.ts
+++ b/src/useRemember.ts
@@ -1,17 +1,16 @@
 import { router } from '@inertiajs/core'
-import { deepTrack } from '@solid-primitives/deep'
-import { createEffect } from 'solid-js'
-import { createStore, unwrap } from 'solid-js/store'
+import { createEffect, createSignal } from 'solid-js'
 
-export default function useRemember<State extends object>(initialState: State, key?: string) {
+export default function useRemember<State extends object>(
+  initialState: State,
+  key?: string,
+): ReturnType<typeof createSignal<State>> {
   const restored = router.restore(key) as State | undefined
-  const [store, setStore] = createStore<State>(restored !== undefined ? restored : initialState)
-
-  const deeplyTrackedStore = () => deepTrack(store)
+  const [signal, setSignal] = createSignal<State>(restored !== undefined ? restored : initialState)
 
   createEffect(() => {
-    router.remember(unwrap(deeplyTrackedStore()), key)
+    router.remember(signal(), key)
   })
 
-  return [store, setStore]
+  return [signal, setSignal]
 }


### PR DESCRIPTION
Initially, I introduced `useRemember()` using [SolidJS' Stores](https://www.solidjs.com/docs/latest/api#stores). Stores provide good DX, but the underlying side-effects of setting the data into the history state get more complicated as stores cannot be tracked from the root; that's why I opted to use the `deepTrack()` primitive, adding complexity to the adapter.

In this case, signals are easier to work with as they provide effortless reactivity tracking.