### PR TITLE
`<Link>` does not ignore the `onClick` event handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inertia-adapter-solid",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "MIT",
   "description": "The SolidJS adapter for Inertia.js",
   "contributors": [

--- a/src/Link.ts
+++ b/src/Link.ts
@@ -21,7 +21,7 @@ type InertiaLinkProps = {
   only?: string[]
   headers?: Record<string, string>
   queryStringArrayFormat?: 'indices' | 'brackets'
-  onClick?: (event: MouseEvent | KeyboardEvent) => void
+  onClick?: (event: MouseEvent) => void
   onCancelToken?: (cancelToken: any) => void
   onBefore?: () => void
   onStart?: () => void
@@ -99,8 +99,10 @@ export default function Link(_props: ParentProps<InertiaLinkProps> & ComponentPr
     }
   }
 
-  const visit = (event: MouseEvent | KeyboardEvent) => {
+  const visit = (event: MouseEvent) => {
     if (isServer) return
+
+    props.onClick?.(event)
 
     // @ts-ignore
     if (shouldIntercept(event)) {
@@ -136,14 +138,7 @@ export default function Link(_props: ParentProps<InertiaLinkProps> & ComponentPr
       get children() {
         return props.children
       },
-      onClick: (e: MouseEvent | KeyboardEvent) => {
-        if (typeof props.onClick === 'function') {
-          props.onClick(e)
-        }
-        if (!e.defaultPrevented) {
-          visit(e)
-        }
-      },
+      onClick: visit,
     }),
   )
 }

--- a/src/Link.ts
+++ b/src/Link.ts
@@ -47,6 +47,7 @@ export default function Link(_props: ParentProps<InertiaLinkProps> & ComponentPr
     'only',
     'headers',
     'queryStringArrayFormat',
+    'onClick',
     'onCancelToken',
     'onBefore',
     'onStart',
@@ -98,7 +99,7 @@ export default function Link(_props: ParentProps<InertiaLinkProps> & ComponentPr
     }
   }
 
-  const visit = (event: MouseEvent) => {
+  const visit = (event: MouseEvent | KeyboardEvent) => {
     if (isServer) return
 
     // @ts-ignore
@@ -135,7 +136,14 @@ export default function Link(_props: ParentProps<InertiaLinkProps> & ComponentPr
       get children() {
         return props.children
       },
-      onClick: (e) => visit(e),
+      onClick: (e: MouseEvent | KeyboardEvent) => {
+        if (typeof props.onClick === 'function') {
+          props.onClick(e)
+        }
+        if (!e.defaultPrevented) {
+          visit(e)
+        }
+      },
     }),
   )
 }


### PR DESCRIPTION
In the current implementation, the `onClick` prop is discarded by the applied `onClick: (e) => visit(e)` handler. 
This fix ensures the handler is correctly passed down and ran. It then only runs the `visit()` function if the event wasn't default prevented, giving the user the possibility to cancel the visit by cancelling the click.

Also added the types to match [the props type](https://github.com/iksaku/inertia-adapter-solid/blob/75d927a7addbe81d4477196772d05a9c82c07a31/src/Link.ts#L24).
