### PR TITLE
Expose `InertiaAppProps` type from the index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { router } from '@inertiajs/core'
+export { type InertiaAppProps } from './App'
 export { default as Link } from './Link'
 export { default as createInertiaApp } from './createInertiaApp'
 export { default as useForm } from './useForm'


### PR DESCRIPTION
Because the `<App />` component receives `InertiaAppProps` as its props, using said type elsewhere is sometimes required. Currently, it's accessible by digging to `"inertia-adapter-solid/dist/types/App"`, which would work but isn't too pretty.

This one liner PR (despite having 7 commits, git rebases ftw) simply exposes the type from the index file, so `import { type InertiaAppProps } from "inertia-adapter-solid"` works. This also makes it more convenient for tsconfig using stricter module resolution modes (`"moduleResolution": "bundler"` in mind here), where `"inertia-adapter-solid/dist/types/App"` is not recognised at all.