### PR TITLE
fix: defaults() call was only working when passing no arguments to it

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -142,7 +142,7 @@ export default function useForm<TForm extends FormState>(
         fieldOrFields = { [fieldOrFields]: maybeValue }
       }
 
-      // setDefaults((defaults) => Object.assign(defaults, fieldOrFields))
+      setDefaults((defaults) => Object.assign(defaults, fieldOrFields))
 
       return this
     },


### PR DESCRIPTION
This PR re-enables code that was previously commented out. Without this code, `form.defaults()` call (after using `useForm`, only works when passing no arguments.